### PR TITLE
Add support for signing operational certificates in Cardano Ledger App

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:ledger_cardano/ledger_cardano.dart';
 import 'package:ledger_flutter/ledger_flutter.dart';
@@ -6,6 +8,8 @@ import 'package:ledger_cardano/src/models/parsed_native_script.dart';
 import 'package:ledger_cardano/src/models/parsed_simple_native_script.dart';
 import 'package:ledger_cardano/src/utils/constants.dart';
 import 'package:ledger_cardano/src/models/parsed_complex_native_script.dart';
+import 'package:ledger_cardano/src/models/parsed_operational_certificate.dart';
+import 'package:ledger_cardano/src/utils/hex_utils.dart';
 
 void main() {
   runApp(const MyApp());
@@ -234,6 +238,39 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
+  Future<void> _testSignOperationalCertificate(LedgerDevice device) async {
+    try {
+      final operationalCertificate = ParsedOperationalCertificate(
+        kesPublicKeyHex: '3d24bc547388cf2403fd978fc3d3a93d1f39acf68a9c00e40512084dc05f2822',
+        kesPeriod: '47',
+        issueCounter: '42',
+        coldKeyPath: [
+          harden + 1853,
+          harden + 1815,
+          harden + 0,
+          harden + 0,
+        ],
+      );
+
+      // Attempt to sign the operational certificate
+      final Uint8List signature = await cardanoApp.signOperationalCertificate(
+        device,
+        operationalCertificate,
+      );
+
+      // Convert the signature to a hex string for comparison
+      final String signatureHex = hex.encode(signature);
+
+      // Log the result
+      print('Operational Certificate Signature: $signatureHex');
+
+      // Here you would compare signatureHex with the expected value manually
+      // In a real app, you might display this on the UI or handle it as needed
+    } catch (e) {
+      print('Error signing operational certificate: $e');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -263,8 +300,10 @@ class _MyAppState extends State<MyApp> {
                         await ledger.connect(device);
 
                         // await _fetchSerial(device);
-                        await _fetchAccount(device);
+                        // await _fetchAccount(device);
                         // await _fetchVersion(device);
+
+                        await _testSignOperationalCertificate(device);
 
                         // await _testDeriveNativeScriptHash(device);
                         // await _testDeriveComplexNativeScriptHash(device);

--- a/lib/src/models/parsed_operational_certificate.dart
+++ b/lib/src/models/parsed_operational_certificate.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:ledger_cardano/src/utils/validation_exception.dart';
+
+part 'parsed_operational_certificate.freezed.dart';
+
+@freezed
+class ParsedOperationalCertificate with _$ParsedOperationalCertificate {
+  ParsedOperationalCertificate._() {
+    // Validate kesPublicKeyHex length
+    if (kesPublicKeyHex.length != 64) {
+      throw ValidationException("KES public key hex must be exactly 64 characters long.");
+    }
+  }
+
+   factory ParsedOperationalCertificate({
+    required String kesPublicKeyHex,
+    required String kesPeriod,
+    required String issueCounter,
+    required List<int> coldKeyPath,
+  }) = ParsedOperationalCertificateData;
+}

--- a/lib/src/models/parsed_operational_certificate.freezed.dart
+++ b/lib/src/models/parsed_operational_certificate.freezed.dart
@@ -1,0 +1,278 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'parsed_operational_certificate.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ParsedOperationalCertificate {
+  String get kesPublicKeyHex => throw _privateConstructorUsedError;
+  String get kesPeriod => throw _privateConstructorUsedError;
+  String get issueCounter => throw _privateConstructorUsedError;
+  List<int> get coldKeyPath => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String kesPublicKeyHex, String kesPeriod,
+            String issueCounter, List<int> coldKeyPath)
+        $default,
+  ) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String kesPublicKeyHex, String kesPeriod,
+            String issueCounter, List<int> coldKeyPath)?
+        $default,
+  ) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String kesPublicKeyHex, String kesPeriod,
+            String issueCounter, List<int> coldKeyPath)?
+        $default, {
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ParsedOperationalCertificateCopyWith<ParsedOperationalCertificate>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ParsedOperationalCertificateCopyWith<$Res> {
+  factory $ParsedOperationalCertificateCopyWith(
+          ParsedOperationalCertificate value,
+          $Res Function(ParsedOperationalCertificate) then) =
+      _$ParsedOperationalCertificateCopyWithImpl<$Res,
+          ParsedOperationalCertificate>;
+  @useResult
+  $Res call(
+      {String kesPublicKeyHex,
+      String kesPeriod,
+      String issueCounter,
+      List<int> coldKeyPath});
+}
+
+/// @nodoc
+class _$ParsedOperationalCertificateCopyWithImpl<$Res,
+        $Val extends ParsedOperationalCertificate>
+    implements $ParsedOperationalCertificateCopyWith<$Res> {
+  _$ParsedOperationalCertificateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? kesPublicKeyHex = null,
+    Object? kesPeriod = null,
+    Object? issueCounter = null,
+    Object? coldKeyPath = null,
+  }) {
+    return _then(_value.copyWith(
+      kesPublicKeyHex: null == kesPublicKeyHex
+          ? _value.kesPublicKeyHex
+          : kesPublicKeyHex // ignore: cast_nullable_to_non_nullable
+              as String,
+      kesPeriod: null == kesPeriod
+          ? _value.kesPeriod
+          : kesPeriod // ignore: cast_nullable_to_non_nullable
+              as String,
+      issueCounter: null == issueCounter
+          ? _value.issueCounter
+          : issueCounter // ignore: cast_nullable_to_non_nullable
+              as String,
+      coldKeyPath: null == coldKeyPath
+          ? _value.coldKeyPath
+          : coldKeyPath // ignore: cast_nullable_to_non_nullable
+              as List<int>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ParsedOperationalCertificateDataImplCopyWith<$Res>
+    implements $ParsedOperationalCertificateCopyWith<$Res> {
+  factory _$$ParsedOperationalCertificateDataImplCopyWith(
+          _$ParsedOperationalCertificateDataImpl value,
+          $Res Function(_$ParsedOperationalCertificateDataImpl) then) =
+      __$$ParsedOperationalCertificateDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String kesPublicKeyHex,
+      String kesPeriod,
+      String issueCounter,
+      List<int> coldKeyPath});
+}
+
+/// @nodoc
+class __$$ParsedOperationalCertificateDataImplCopyWithImpl<$Res>
+    extends _$ParsedOperationalCertificateCopyWithImpl<$Res,
+        _$ParsedOperationalCertificateDataImpl>
+    implements _$$ParsedOperationalCertificateDataImplCopyWith<$Res> {
+  __$$ParsedOperationalCertificateDataImplCopyWithImpl(
+      _$ParsedOperationalCertificateDataImpl _value,
+      $Res Function(_$ParsedOperationalCertificateDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? kesPublicKeyHex = null,
+    Object? kesPeriod = null,
+    Object? issueCounter = null,
+    Object? coldKeyPath = null,
+  }) {
+    return _then(_$ParsedOperationalCertificateDataImpl(
+      kesPublicKeyHex: null == kesPublicKeyHex
+          ? _value.kesPublicKeyHex
+          : kesPublicKeyHex // ignore: cast_nullable_to_non_nullable
+              as String,
+      kesPeriod: null == kesPeriod
+          ? _value.kesPeriod
+          : kesPeriod // ignore: cast_nullable_to_non_nullable
+              as String,
+      issueCounter: null == issueCounter
+          ? _value.issueCounter
+          : issueCounter // ignore: cast_nullable_to_non_nullable
+              as String,
+      coldKeyPath: null == coldKeyPath
+          ? _value._coldKeyPath
+          : coldKeyPath // ignore: cast_nullable_to_non_nullable
+              as List<int>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ParsedOperationalCertificateDataImpl
+    extends ParsedOperationalCertificateData {
+  _$ParsedOperationalCertificateDataImpl(
+      {required this.kesPublicKeyHex,
+      required this.kesPeriod,
+      required this.issueCounter,
+      required final List<int> coldKeyPath})
+      : _coldKeyPath = coldKeyPath,
+        super._();
+
+  @override
+  final String kesPublicKeyHex;
+  @override
+  final String kesPeriod;
+  @override
+  final String issueCounter;
+  final List<int> _coldKeyPath;
+  @override
+  List<int> get coldKeyPath {
+    if (_coldKeyPath is EqualUnmodifiableListView) return _coldKeyPath;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_coldKeyPath);
+  }
+
+  @override
+  String toString() {
+    return 'ParsedOperationalCertificate(kesPublicKeyHex: $kesPublicKeyHex, kesPeriod: $kesPeriod, issueCounter: $issueCounter, coldKeyPath: $coldKeyPath)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ParsedOperationalCertificateDataImpl &&
+            (identical(other.kesPublicKeyHex, kesPublicKeyHex) ||
+                other.kesPublicKeyHex == kesPublicKeyHex) &&
+            (identical(other.kesPeriod, kesPeriod) ||
+                other.kesPeriod == kesPeriod) &&
+            (identical(other.issueCounter, issueCounter) ||
+                other.issueCounter == issueCounter) &&
+            const DeepCollectionEquality()
+                .equals(other._coldKeyPath, _coldKeyPath));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, kesPublicKeyHex, kesPeriod,
+      issueCounter, const DeepCollectionEquality().hash(_coldKeyPath));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ParsedOperationalCertificateDataImplCopyWith<
+          _$ParsedOperationalCertificateDataImpl>
+      get copyWith => __$$ParsedOperationalCertificateDataImplCopyWithImpl<
+          _$ParsedOperationalCertificateDataImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String kesPublicKeyHex, String kesPeriod,
+            String issueCounter, List<int> coldKeyPath)
+        $default,
+  ) {
+    return $default(kesPublicKeyHex, kesPeriod, issueCounter, coldKeyPath);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String kesPublicKeyHex, String kesPeriod,
+            String issueCounter, List<int> coldKeyPath)?
+        $default,
+  ) {
+    return $default?.call(
+        kesPublicKeyHex, kesPeriod, issueCounter, coldKeyPath);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String kesPublicKeyHex, String kesPeriod,
+            String issueCounter, List<int> coldKeyPath)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(kesPublicKeyHex, kesPeriod, issueCounter, coldKeyPath);
+    }
+    return orElse();
+  }
+}
+
+abstract class ParsedOperationalCertificateData
+    extends ParsedOperationalCertificate {
+  factory ParsedOperationalCertificateData(
+          {required final String kesPublicKeyHex,
+          required final String kesPeriod,
+          required final String issueCounter,
+          required final List<int> coldKeyPath}) =
+      _$ParsedOperationalCertificateDataImpl;
+  ParsedOperationalCertificateData._() : super._();
+
+  @override
+  String get kesPublicKeyHex;
+  @override
+  String get kesPeriod;
+  @override
+  String get issueCounter;
+  @override
+  List<int> get coldKeyPath;
+  @override
+  @JsonKey(ignore: true)
+  _$$ParsedOperationalCertificateDataImplCopyWith<
+          _$ParsedOperationalCertificateDataImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/models/version_compatibility.dart
+++ b/lib/src/models/version_compatibility.dart
@@ -11,17 +11,20 @@ class VersionCompatibility with _$VersionCompatibility {
     required bool isCompatible,
     required String? recommendedVersion,
     required bool supportsNativeScriptHashDerivation,
+    required bool supportsOperationalCertificateSigning,
   }) = _VersionCompatibility;
 
-  factory VersionCompatibility.checkVersionCompatibility(
-      CardanoVersion version) {
+  factory VersionCompatibility.checkVersionCompatibility(CardanoVersion version) {
     final bool isCompatible = version.versionMajor >= 3;
     final bool supportsNativeScriptHashDerivation = version.versionMajor >= 3;
+    final bool supportsOperationalCertificateSigning =
+        version.versionMajor > 2 || (version.versionMajor == 2 && version.versionMinor >= 4);
 
     return VersionCompatibility(
       isCompatible: isCompatible,
       recommendedVersion: isCompatible ? null : ">=3.0.0",
       supportsNativeScriptHashDerivation: supportsNativeScriptHashDerivation,
+      supportsOperationalCertificateSigning: supportsOperationalCertificateSigning,
     );
   }
 }

--- a/lib/src/models/version_compatibility.freezed.dart
+++ b/lib/src/models/version_compatibility.freezed.dart
@@ -20,24 +20,35 @@ mixin _$VersionCompatibility {
   String? get recommendedVersion => throw _privateConstructorUsedError;
   bool get supportsNativeScriptHashDerivation =>
       throw _privateConstructorUsedError;
+  bool get supportsOperationalCertificateSigning =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(bool isCompatible, String? recommendedVersion,
-            bool supportsNativeScriptHashDerivation)
+    TResult Function(
+            bool isCompatible,
+            String? recommendedVersion,
+            bool supportsNativeScriptHashDerivation,
+            bool supportsOperationalCertificateSigning)
         $default,
   ) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(bool isCompatible, String? recommendedVersion,
-            bool supportsNativeScriptHashDerivation)?
+    TResult? Function(
+            bool isCompatible,
+            String? recommendedVersion,
+            bool supportsNativeScriptHashDerivation,
+            bool supportsOperationalCertificateSigning)?
         $default,
   ) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(bool isCompatible, String? recommendedVersion,
-            bool supportsNativeScriptHashDerivation)?
+    TResult Function(
+            bool isCompatible,
+            String? recommendedVersion,
+            bool supportsNativeScriptHashDerivation,
+            bool supportsOperationalCertificateSigning)?
         $default, {
     required TResult orElse(),
   }) =>
@@ -57,7 +68,8 @@ abstract class $VersionCompatibilityCopyWith<$Res> {
   $Res call(
       {bool isCompatible,
       String? recommendedVersion,
-      bool supportsNativeScriptHashDerivation});
+      bool supportsNativeScriptHashDerivation,
+      bool supportsOperationalCertificateSigning});
 }
 
 /// @nodoc
@@ -77,6 +89,7 @@ class _$VersionCompatibilityCopyWithImpl<$Res,
     Object? isCompatible = null,
     Object? recommendedVersion = freezed,
     Object? supportsNativeScriptHashDerivation = null,
+    Object? supportsOperationalCertificateSigning = null,
   }) {
     return _then(_value.copyWith(
       isCompatible: null == isCompatible
@@ -91,6 +104,11 @@ class _$VersionCompatibilityCopyWithImpl<$Res,
               supportsNativeScriptHashDerivation
           ? _value.supportsNativeScriptHashDerivation
           : supportsNativeScriptHashDerivation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      supportsOperationalCertificateSigning: null ==
+              supportsOperationalCertificateSigning
+          ? _value.supportsOperationalCertificateSigning
+          : supportsOperationalCertificateSigning // ignore: cast_nullable_to_non_nullable
               as bool,
     ) as $Val);
   }
@@ -107,7 +125,8 @@ abstract class _$$VersionCompatibilityImplCopyWith<$Res>
   $Res call(
       {bool isCompatible,
       String? recommendedVersion,
-      bool supportsNativeScriptHashDerivation});
+      bool supportsNativeScriptHashDerivation,
+      bool supportsOperationalCertificateSigning});
 }
 
 /// @nodoc
@@ -124,6 +143,7 @@ class __$$VersionCompatibilityImplCopyWithImpl<$Res>
     Object? isCompatible = null,
     Object? recommendedVersion = freezed,
     Object? supportsNativeScriptHashDerivation = null,
+    Object? supportsOperationalCertificateSigning = null,
   }) {
     return _then(_$VersionCompatibilityImpl(
       isCompatible: null == isCompatible
@@ -139,6 +159,11 @@ class __$$VersionCompatibilityImplCopyWithImpl<$Res>
           ? _value.supportsNativeScriptHashDerivation
           : supportsNativeScriptHashDerivation // ignore: cast_nullable_to_non_nullable
               as bool,
+      supportsOperationalCertificateSigning: null ==
+              supportsOperationalCertificateSigning
+          ? _value.supportsOperationalCertificateSigning
+          : supportsOperationalCertificateSigning // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -149,7 +174,8 @@ class _$VersionCompatibilityImpl extends _VersionCompatibility {
   const _$VersionCompatibilityImpl(
       {required this.isCompatible,
       required this.recommendedVersion,
-      required this.supportsNativeScriptHashDerivation})
+      required this.supportsNativeScriptHashDerivation,
+      required this.supportsOperationalCertificateSigning})
       : super._();
 
   @override
@@ -158,10 +184,12 @@ class _$VersionCompatibilityImpl extends _VersionCompatibility {
   final String? recommendedVersion;
   @override
   final bool supportsNativeScriptHashDerivation;
+  @override
+  final bool supportsOperationalCertificateSigning;
 
   @override
   String toString() {
-    return 'VersionCompatibility(isCompatible: $isCompatible, recommendedVersion: $recommendedVersion, supportsNativeScriptHashDerivation: $supportsNativeScriptHashDerivation)';
+    return 'VersionCompatibility(isCompatible: $isCompatible, recommendedVersion: $recommendedVersion, supportsNativeScriptHashDerivation: $supportsNativeScriptHashDerivation, supportsOperationalCertificateSigning: $supportsOperationalCertificateSigning)';
   }
 
   @override
@@ -176,12 +204,20 @@ class _$VersionCompatibilityImpl extends _VersionCompatibility {
             (identical(other.supportsNativeScriptHashDerivation,
                     supportsNativeScriptHashDerivation) ||
                 other.supportsNativeScriptHashDerivation ==
-                    supportsNativeScriptHashDerivation));
+                    supportsNativeScriptHashDerivation) &&
+            (identical(other.supportsOperationalCertificateSigning,
+                    supportsOperationalCertificateSigning) ||
+                other.supportsOperationalCertificateSigning ==
+                    supportsOperationalCertificateSigning));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, isCompatible, recommendedVersion,
-      supportsNativeScriptHashDerivation);
+  int get hashCode => Object.hash(
+      runtimeType,
+      isCompatible,
+      recommendedVersion,
+      supportsNativeScriptHashDerivation,
+      supportsOperationalCertificateSigning);
 
   @JsonKey(ignore: true)
   @override
@@ -194,36 +230,54 @@ class _$VersionCompatibilityImpl extends _VersionCompatibility {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(bool isCompatible, String? recommendedVersion,
-            bool supportsNativeScriptHashDerivation)
+    TResult Function(
+            bool isCompatible,
+            String? recommendedVersion,
+            bool supportsNativeScriptHashDerivation,
+            bool supportsOperationalCertificateSigning)
         $default,
   ) {
     return $default(
-        isCompatible, recommendedVersion, supportsNativeScriptHashDerivation);
+        isCompatible,
+        recommendedVersion,
+        supportsNativeScriptHashDerivation,
+        supportsOperationalCertificateSigning);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(bool isCompatible, String? recommendedVersion,
-            bool supportsNativeScriptHashDerivation)?
+    TResult? Function(
+            bool isCompatible,
+            String? recommendedVersion,
+            bool supportsNativeScriptHashDerivation,
+            bool supportsOperationalCertificateSigning)?
         $default,
   ) {
     return $default?.call(
-        isCompatible, recommendedVersion, supportsNativeScriptHashDerivation);
+        isCompatible,
+        recommendedVersion,
+        supportsNativeScriptHashDerivation,
+        supportsOperationalCertificateSigning);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(bool isCompatible, String? recommendedVersion,
-            bool supportsNativeScriptHashDerivation)?
+    TResult Function(
+            bool isCompatible,
+            String? recommendedVersion,
+            bool supportsNativeScriptHashDerivation,
+            bool supportsOperationalCertificateSigning)?
         $default, {
     required TResult orElse(),
   }) {
     if ($default != null) {
       return $default(
-          isCompatible, recommendedVersion, supportsNativeScriptHashDerivation);
+          isCompatible,
+          recommendedVersion,
+          supportsNativeScriptHashDerivation,
+          supportsOperationalCertificateSigning);
     }
     return orElse();
   }
@@ -233,7 +287,8 @@ abstract class _VersionCompatibility extends VersionCompatibility {
   const factory _VersionCompatibility(
           {required final bool isCompatible,
           required final String? recommendedVersion,
-          required final bool supportsNativeScriptHashDerivation}) =
+          required final bool supportsNativeScriptHashDerivation,
+          required final bool supportsOperationalCertificateSigning}) =
       _$VersionCompatibilityImpl;
   const _VersionCompatibility._() : super._();
 
@@ -243,6 +298,8 @@ abstract class _VersionCompatibility extends VersionCompatibility {
   String? get recommendedVersion;
   @override
   bool get supportsNativeScriptHashDerivation;
+  @override
+  bool get supportsOperationalCertificateSigning;
   @override
   @JsonKey(ignore: true)
   _$$VersionCompatibilityImplCopyWith<_$VersionCompatibilityImpl>

--- a/lib/src/operations/cardano_sign_operational_certificate_operation.dart
+++ b/lib/src/operations/cardano_sign_operational_certificate_operation.dart
@@ -1,0 +1,32 @@
+import 'dart:typed_data';
+
+import 'package:ledger_cardano/src/models/parsed_operational_certificate.dart';
+import 'package:ledger_cardano/src/operations/complex_ledger_operations.dart';
+import 'package:ledger_cardano/src/operations/ledger_operations.dart';
+import 'package:ledger_cardano/src/utils/constants.dart';
+import 'package:ledger_cardano/src/utils/serialization_utils.dart';
+
+class CardanoSignOperationalCertificateOperation extends ComplexLedgerOperation<Uint8List> {
+  final ParsedOperationalCertificate operationalCertificate;
+
+  const CardanoSignOperationalCertificateOperation({
+    required this.operationalCertificate,
+  });
+
+  @override
+  Future<Uint8List> invoke(LedgerSendFct send) async {
+    final data = SerializationUtils.serializeOperationalCertificate(operationalCertificate);
+
+    final response = await send(
+      SendOperation(
+        ins: InstructionType.signOperationalCertificate.insValue,
+        p1: p1Unused,
+        p2: p2Unused,
+        data: data,
+        prependDataLength: true,
+      ),
+    );
+
+    return response.read(ed25519SignatureLength);
+  }
+}

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -6,6 +6,7 @@ const int p1Unused = 0x00;
 const int p1ReturnDataToHost = 0x01;
 const int p1DisplayOnDevice = 0x02;
 const int p1FinishScriptHash = 0x03;
+const int ed25519SignatureLength = 64;
 
 const int p2Unused = 0x00;
 
@@ -64,7 +65,8 @@ enum InstructionType {
   getVersion(insValue: 0x00),
   getExtendedPublicKey(insValue: 0x10),
   getSerial(insValue: 0x01),
-  deriveNativeScriptHash(insValue: 0x12);
+  deriveNativeScriptHash(insValue: 0x12),
+  signOperationalCertificate(insValue: 0x22);
 
   final int insValue;
 


### PR DESCRIPTION
- Imported `dart:typed_data` for handling binary data operations.
- Added `parsed_operational_certificate.dart` and `hex_utils.dart` to support operational certificate processing.
- Implemented `_testSignOperationalCertificate` method in the main Dart file to test operational certificate signing functionality.
- Updated `CardanoLedgerApp` class to include a new method `signOperationalCertificate` for signing operational certificates.
- Enhanced `VersionCompatibility` to check for operational certificate signing support based on the Cardano app version on the Ledger device.
- Added new constant `ed25519SignatureLength` and a new instruction type `signOperationalCertificate` to handle operational certificate signing.
- Extended `SerializationUtils` with `serializeOperationalCertificate` for proper serialization of operational certificates.